### PR TITLE
Fix loot analyser (#2531)

### DIFF
--- a/src/container.cpp
+++ b/src/container.cpp
@@ -183,6 +183,19 @@ bool Container::unserializeItemNode(OTB::Loader& loader, const OTB::Node& node, 
 	return true;
 }
 
+bool Container::countsToLootAnalyzerBalance()
+{
+	if (isCorpse()) {
+		return true;
+	}
+
+	if (getID() == ITEM_REWARD_CONTAINER) {
+		return true;
+	}
+
+	return false;
+}
+
 void Container::updateItemWeight(int32_t diff)
 {
 	totalWeight += diff;

--- a/src/container.h
+++ b/src/container.h
@@ -117,6 +117,7 @@ class Container : public Item, public Cylinder
 			return itemlist.rend();
 		}
 
+		bool countsToLootAnalyzerBalance();
 		bool hasParent() const;
 		void addItem(Item* item);
 		StashContainerList getStowableItems() const;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1592,16 +1592,15 @@ void Game::playerMoveItem(Player* player, const Position& fromPos,
 	ReturnValue ret = internalMoveItem(fromCylinder, toCylinder, toIndex, item, count, nullptr, 0, player);
 	if (ret != RETURNVALUE_NOERROR) {
 		player->sendCancelMessage(ret);
-	} else {
-		if (toCylinder->getContainer() != nullptr && fromCylinder->getContainer() != nullptr
-			&& fromCylinder->getContainer()->isCorpse()
-			&& toCylinder->getContainer()->getTopParent() == player) {
-			player->sendLootStats(item, count);
-		}
-		player->cancelPush();
-
-		g_events->eventPlayerOnItemMoved(player, item, count, fromPos, toPos, fromCylinder, toCylinder);
+	}	else if (toCylinder->getContainer()
+		&& fromCylinder->getContainer()
+		&& fromCylinder->getContainer()->countsToLootAnalyzerBalance()
+		&& toCylinder->getContainer()->getTopParent() == player) {
+		player->sendLootStats(item, count);
 	}
+	player->cancelPush();
+
+	g_events->eventPlayerOnItemMoved(player, item, count, fromPos, toPos, fromCylinder, toCylinder);
 }
 
 ReturnValue Game::internalMoveItem(Cylinder* fromCylinder, Cylinder* toCylinder, int32_t index,


### PR DESCRIPTION
* Fix loot analyser

Now when you loot an item from a reward bag it will increase your Loot Analyser Balance.

Thanks to @lgrossi

Co-Authored-By: Lucas Grossi <34237492+lgrossi@users.noreply.github.com>

* Update container.cpp

added whiteline

Co-authored-by: Lucas Grossi <34237492+lgrossi@users.noreply.github.com>